### PR TITLE
fixed dependencies for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=0.12.3
 flask_sqlalchemy==2.3.2
+mock>=3.0.5

--- a/test_flaskr.py
+++ b/test_flaskr.py
@@ -104,7 +104,7 @@ class FlaskrTestCase(unittest.TestCase):
         rv = self.app.get('/delete/1')
         data = json.loads(rv.data)
         self.assertEqual(data['status'], 0)
-        self.assertEqual(data['message'], "Exception('Some message')")
+        self.assertEqual(data['message'], "Exception('Some message',)")
 
     def test_post_fail_without_login(self):
         """Ensure anonymous users can't make blog post"""

--- a/test_flaskr.py
+++ b/test_flaskr.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from unittest.mock import patch, Mock
+from mock import patch, Mock
 
 from flask import json
 
@@ -104,7 +104,7 @@ class FlaskrTestCase(unittest.TestCase):
         rv = self.app.get('/delete/1')
         data = json.loads(rv.data)
         self.assertEqual(data['status'], 0)
-        self.assertEqual(data['message'], "Exception('Some message',)")
+        self.assertEqual(data['message'], "Exception('Some message')")
 
     def test_post_fail_without_login(self):
         """Ensure anonymous users can't make blog post"""


### PR DESCRIPTION
For Python versions < 3.3 mock is not yet part of the standard library. The only way to use it then is by installing [the package](https://pypi.org/project/mock/) itself.

This should fix #14 